### PR TITLE
SelectDB: Support when database argument is array

### DIFF
--- a/Function/FieldName.php
+++ b/Function/FieldName.php
@@ -33,7 +33,7 @@ class MySQLConverterTool_Function_FieldName extends MySQLConverterTool_Function_
             
         list($res, $i) = $this->extractParamValues($params);
         
-        return array(NULL, sprintf('((($___mysqli_tmp = mysqli_fetch_field_direct(%s, %d)->name) && (!is_null($___mysqli_tmp))) ? $___mysqli_tmp : false)', $res, $i));
+        return array(NULL, sprintf('((($___mysqli_tmp = mysqli_fetch_field_direct(%s, %s)->name) && (!is_null($___mysqli_tmp))) ? $___mysqli_tmp : false)', $res, $i));
     }
     
     

--- a/Function/SelectDB.php
+++ b/Function/SelectDB.php
@@ -39,7 +39,7 @@ class MySQLConverterTool_Function_SelectDB extends MySQLConverterTool_Function_G
         if ('const' == $db_type) {
             $ret = sprintf('((bool)mysqli_query(%s, "USE " . constant(\'%s\')))', $conn, $db);
         } else {
-            $ret = sprintf('((bool)mysqli_query(%s, "USE %s"))', $conn, $db);
+            $ret = sprintf('((bool)mysqli_query(%s, "USE " . %s))', $conn, $db);
         }
         
         return array('mysql_select_db(string database_name [...]) is emulated using mysqli_query() and USE database_name. This is a possible SQL injection security bug as no tests are performed what value database_name has. Check your script!', $ret);


### PR DESCRIPTION
When using mysql statements like mysql_select_db($cfg["mysqldb"]);
the tool produced invalid php syntax:
((bool)mysqli_query($GLOBALS["___mysqli_ston"], "USE $cfg["mysqldb"]"));
resulting in
PHP Parse error:  syntax error, unexpected '"', expecting T_STRING or T_VARIABLE or T_NUM_STRING

After this patch, the result is
((bool)mysqli_query($GLOBALS["___mysqli_ston"], "USE " . $cfg["mysqldb"]));

A test should be added, but I am not skilled enough to add one :(

§