### PR TITLE
Fixed the mysqli_result() example function to have the same return-ty…

### DIFF
--- a/Function/Result.php
+++ b/Function/Result.php
@@ -48,10 +48,10 @@ class MySQLConverterTool_Function_Result extends MySQLConverterTool_Function_Gen
             mysqli_data_seek($result, $number);
             $type = is_numeric($field) ? MYSQLI_NUM : MYSQLI_ASSOC;
             $out = mysqli_fetch_array($result, $type);
-            if ($out === NULL || $out === FALSE) {
+            if ($out === NULL || $out === FALSE || (!isset($out[$field]))) {
                 return FALSE;
             }
-            return $out;
+            return $out[$field];
         }
         ';
     }


### PR DESCRIPTION
…pe that mysql_result() has.

Previously, this function was returning an array, but the mysql_function() is supposed to return a specific result. If the field does not exist, it should return false (and now it does).  I used this new function in a site with a large number of calls to mysql_result() and the conversion seems to have been successful once this change was added.