### PR TITLE
Deals with issue #22, blindly adds backticks in case dbname requires them

### DIFF
--- a/Function/ListTables.php
+++ b/Function/ListTables.php
@@ -43,10 +43,10 @@ class MySQLConverterTool_Function_ListTables extends MySQLConverterTool_Function
         if ('const' == $db_type) {
             $ret = sprintf('mysqli_query(%s, "SHOW TABLES FROM " . constant(\'%s\'))', $conn, $db);
         } else {
-            $ret = sprintf('mysqli_query(%s, "SHOW TABLES FROM %s")', $conn, $db);
+            $ret = sprintf('mysqli_query(%s, "SHOW TABLES FROM `%s`")', $conn, $db);
         }
 
-        return array('mysql_list_tables(string database_name [...]) is emulated using mysqli_query() and SHOW TABLES FROM database_name. This is a possible SQL injection security bug as no tests are performed what value database_name has. Check your script!', $ret);
+        return array('mysql_list_tables(string database_name [...]) is emulated using mysqli_query() and SHOW TABLES FROM `database_name`. This is a possible SQL injection security bug as no tests are performed what value database_name has. Check your script!', $ret);
     }
 
     public function getConversionHint()

--- a/UnitTests/Function/ListTablesTest.php
+++ b/UnitTests/Function/ListTablesTest.php
@@ -50,7 +50,7 @@ class MySQLConverterTool_UnitTests_Function_ListTablesTest extends MySQLConverte
         list($warning, $code) = $this->gen->handle($this->buildParams(array('"<database>"')));
         $this->assertNotNull($warning);
         $this->assertEquals(
-            sprintf('%s(%s, "SHOW TABLES FROM <database>")', $this->gen->new_name, $this->default_conn),
+            sprintf('%s(%s, "SHOW TABLES FROM `<database>`")', $this->gen->new_name, $this->default_conn),
             $code
         );
 
@@ -66,7 +66,7 @@ class MySQLConverterTool_UnitTests_Function_ListTablesTest extends MySQLConverte
         list($warning, $code) = $this->gen->handle($this->buildParams(array('$<database>', '<link_identifier>')));
         $this->assertNotNull($warning);
         $this->assertEquals(
-            sprintf('%s(<link_identifier>, "SHOW TABLES FROM $<database>")', $this->gen->new_name),
+            sprintf('%s(<link_identifier>, "SHOW TABLES FROM `$<database>`")', $this->gen->new_name),
             $code
         );
 


### PR DESCRIPTION
Not well tested yet, but this appears safe. 