### PR TITLE
Fixed found incompatibility with PHP 8.0

### DIFF
--- a/Converter.php
+++ b/Converter.php
@@ -394,7 +394,7 @@ class MySQLConverterTool_Converter
             }
             if ($this->skip_pattern !== false) {
                 if ($this->skip_pattern === '.') {
-                    if ($file{0} === '.') {
+                    if ($file[0] === '.') {
                         continue;
                     }
                 } else {
@@ -495,7 +495,9 @@ class MySQLConverterTool_Converter
         // flag for something that looks like a mysql_func call but is not followed by parameters
         $expect_param_brace_open = false;
 
-        while (list(, $token) = each($this->tokens)) {
+        while (null !== key($this->tokens)) {
+            $token = current($this->tokens);
+            next($this->tokens);
             if (is_string($token)) {
                 $id = T_SIMPLE_TOKEN;
                 $token_name = 'T_SIMPLE_TOKEN';
@@ -809,7 +811,7 @@ class MySQLConverterTool_Converter
                         }
 
                         while ($prev_steps--) {
-                            each($this->tokens);
+                            next($this->tokens);
                         }
                     }
                 }

--- a/cli.php
+++ b/cli.php
@@ -41,12 +41,14 @@ function parseOptions($argc, $argv)
     // skip $argv[0] - program name
     next($argv);
 
-    while (list($k, $arg) = each($argv)) {
-        $arg = trim($arg);
+    while ($k = key($argv)) {
+        $arg = trim(current($argv));
+        next($argv);
         switch ($arg) {
             case '-f':
-                if (list($k, $arg) = each($argv)) {
-                    $arg = trim($arg);
+                if ($k = key($argv)) {
+                    $arg = trim(current($argv));
+                    next($argv);
                     if (substr($arg, 0, 1) == '-') {
                         $error = '-f needs a file name';
                         break 2;
@@ -69,8 +71,9 @@ function parseOptions($argc, $argv)
                 break;
 
             case '-d':
-                if (list($k, $arg) = each($argv)) {
-                    $arg = trim($arg);
+                if ($k = key($argv)) {
+                    $arg = trim(current($argv));
+                    next($argv);
                     if (substr($arg, 0, 1) == '-') {
                         $error = '-d needs a directory name';
                         break 2;
@@ -93,8 +96,9 @@ function parseOptions($argc, $argv)
                 break;
 
             case '-s':
-                if (list($k, $arg) = each($argv)) {
-                    $arg = trim($arg);
+                if ($k = key($argv)) {
+                    $arg = trim(current($argv));
+                    next($argv);
                     if ('' == $arg) {
                         $error = '-s expects a code snippet to follow the option';
                         break 2;
@@ -140,8 +144,9 @@ function parseOptions($argc, $argv)
                 break;
 
             case '-p':
-                if (list($k, $arg) = each($argv)) {
-                    $arg = trim($arg);
+                if ($k = key($argv)) {
+                    $arg = trim(current($argv));
+                    next($argv);
                     if ('' == $arg) {
                         $error = '-p needs a search pattern';
                         break 2;


### PR DESCRIPTION
Array and string offset access syntax with curly braces and function `each` are deprecated in PHP 8.0, so those parts were rewritten.